### PR TITLE
added proxy support

### DIFF
--- a/lib/mediawiki_api/client.rb
+++ b/lib/mediawiki_api/client.rb
@@ -15,8 +15,8 @@ module MediawikiApi
   class Client
     attr_accessor :logged_in
 
-    def initialize(url, log=false)
-      @conn = Faraday.new(url: url) do |faraday|
+    def initialize(url, log=false, proxy=nil )
+      @conn = Faraday.new(url: url, proxy: proxy) do |faraday|
         faraday.request :url_encoded
         if log then
           faraday.response :logger


### PR DESCRIPTION
**Usage:**

```
proxy_settings = {
  :uri      => 'http://127.0.0.1:8118',
  :user     => nil,
  :password => nil
  }

 client = MediawikiApi::Client.new("http://127.0.0.1/w/api.php", nil, proxy_settings)
```
