### PR TITLE
Add the option to create generic mock ApiErrors without passing in a real response.

### DIFF
--- a/lib/mediawiki_api/client.rb
+++ b/lib/mediawiki_api/client.rb
@@ -179,7 +179,7 @@ module MediawikiApi
       params = params.clone
 
       method = params.delete(:http_method) || :post
-      token_type = params.delete(:token_type)
+      token_type = params.delete(:token_type) || false
       envelope = (params.delete(:envelope) || [name]).map(&:to_s)
 
       params[:token] = get_token(token_type || name) unless token_type == false

--- a/lib/mediawiki_api/exceptions.rb
+++ b/lib/mediawiki_api/exceptions.rb
@@ -3,16 +3,16 @@ module MediawikiApi
   class ApiError < StandardError
     attr_reader :response
 
-    def initialize(response)
+    def initialize(response=nil)
       @response = response
     end
 
     def code
-      data['code']
+      response ? data['code'] : '000'
     end
 
     def info
-      data['info']
+      response ? data['info'] : 'generic MediawikiApi gem example error'
     end
 
     def to_s
@@ -22,7 +22,11 @@ module MediawikiApi
     private
 
     def data
-      @response.data || {}
+      if response
+        @response.data || {}
+      else
+        nil
+      end
     end
   end
 

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe MediawikiApi::ApiError do
-  it 'should create a generic ApiError when initiated with no data' do
+  it 'should create a generic ApiError when initialized with no data' do
     mock_error = MediawikiApi::ApiError.new
     expect(mock_error).to be_a(MediawikiApi::ApiError)
   end

--- a/spec/exceptions_spec.rb
+++ b/spec/exceptions_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe MediawikiApi::ApiError do
+  it 'should create a generic ApiError when initiated with no data' do
+    mock_error = MediawikiApi::ApiError.new
+    expect(mock_error).to be_a(MediawikiApi::ApiError)
+  end
+end


### PR DESCRIPTION
This is useful for writing tests for app that use this gem and need to handle ApiErrors. Here's the workaround I have in my project, each time I want to stub an ApiError:

```
  it 'should handle MediaWiki API errors' do
    error = MediawikiApi::ApiError.new nil
    allow(error).to receive(:data).and_return({})
    allow(error).to receive(:info).and_return('bar')
    stub_request(:any, %r{.*wikipedia\.org/w/api\.php.*})
      .to_raise(error)
    CourseImporter.update_all_courses(false, { first: '798', second: '800' })

    course = create(:course, id: 519)
    course.manual_update
  end
```

With this patch, I could just do this, without monkeypatching ApiError:
```    
stub_request(:any, %r{.*wikipedia\.org/w/api\.php.*})
      .to_raise(MediawikiApi::ApiError.new)
```
