### PR TITLE
Remove superfluous version constraint on faraday

### DIFF
--- a/mediawiki_api.gemspec
+++ b/mediawiki_api.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.0'
+  spec.add_runtime_dependency 'faraday', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.10', '>= 0.10.0'
 


### PR DESCRIPTION
The *pessimistic version constraint* `~> 0.9` takes precedence over (or, is more restrictive than) the *optimistic* version constraint `>= 0.9.0`. Therefore, the latter is superfluous.