### PR TITLE
Remove maximum gem versions for http libraries

### DIFF
--- a/mediawiki_api.gemspec
+++ b/mediawiki_api.gemspec
@@ -23,15 +23,15 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)/)
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.0'
-  spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.10', '>= 0.10.0'
+  spec.add_runtime_dependency 'faraday', '>= 0.9.0'
+  spec.add_runtime_dependency 'faraday-cookie_jar', '>= 0.0.6'
+  spec.add_runtime_dependency 'faraday_middleware', '>= 0.10.0'
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake', '~> 0'
   spec.add_development_dependency 'rspec', '~> 3.0', '>= 3.0.0'
   spec.add_development_dependency 'rubocop', '~> 0.51.0'
-  spec.add_development_dependency 'webmock', '~> 1.17', '>= 1.17.2'
+  spec.add_development_dependency 'webmock', '>= 1.17.2'
   spec.add_development_dependency 'redcarpet'
   spec.add_development_dependency 'yard'
 end


### PR DESCRIPTION
The gems faraday and faraday_middleware have 1.x releases, and webmock is on version 3.x.

Removing the major version specifier allows this gem to be compatible with the latest versions of these industry-standard libraries. The test suite passes on the latest versions of all these gems.

I've also deployed my fork to Wiki Education Dashboard, which is working smoothly.